### PR TITLE
fix(ui): restore input and select border, hover, and focus styles

### DIFF
--- a/src/ui/input/index.module.css
+++ b/src/ui/input/index.module.css
@@ -1,17 +1,21 @@
-@layer components {
-  .container {
-    @apply relative flex flex-col mb-2;
+.container {
+  @apply relative flex flex-col mb-2;
+}
 
-    label {
-      @apply ml-1 text-[14px] mb-1 op-50;
-    }
+.container label {
+  @apply ml-1 text-[14px] mb-1 op-50;
+}
 
-    input {
-      @apply focus:outline-0;
-      @apply py-1 px-2 text-[14px];
-      @apply w-full bg-brand-background;
-      @apply border-1 rounded-sm transition-all;
-      @apply hover:ring-1 hover:ring-brand-primary hover:bg-brand-secondary;
-    }
-  }
+.container input {
+  @apply py-1 px-2 text-[14px];
+  @apply w-full bg-brand-background;
+  @apply border-1 rounded-sm transition-all;
+}
+
+.container input:hover {
+  @apply ring-1 ring-brand-primary bg-brand-secondary;
+}
+
+.container input:focus {
+  @apply outline-none ring-1 ring-brand-primary;
 }

--- a/src/ui/select/index.module.css
+++ b/src/ui/select/index.module.css
@@ -1,17 +1,24 @@
 .container {
   @apply relative flex flex-col mb-2;
+}
 
-  label {
-    @apply ml-1 text-[14px] mb-1 op-50;
-  }
+.container label {
+  @apply ml-1 text-[14px] mb-1 op-50;
+}
 
-  select {
-    @apply appearance-none focus:outline-none;
-    @apply py-1 px-2 text-[14px];
-    @apply w-full bg-brand-background;
-    @apply border-1 rounded-sm transition-all;
-    @apply hover:ring-1 hover:ring-brand-primary hover:text-brand-primary hover:bg-brand-secondary;
-  }
+.container select {
+  @apply appearance-none;
+  @apply py-1 px-2 text-[14px];
+  @apply w-full bg-brand-background;
+  @apply border-1 rounded-sm transition-all;
+}
+
+.container select:hover {
+  @apply ring-1 ring-brand-primary text-brand-primary bg-brand-secondary;
+}
+
+.container select:focus {
+  @apply outline-none ring-1 ring-brand-primary;
 }
 
 .dropdown {


### PR DESCRIPTION
## Summary

- Drop the `@layer components` wrapper from `src/ui/input/index.module.css`. After the Vite 8 migration (#6030062) removed the `@layer reset, base, utilities, components;` declaration from `globals.css`, the UnoCSS reset became unlayered and its `border-width: 0` rule began beating the layered `border-1`, so `Input` borders disappeared in the extension popup.
- Flatten the hover/focus styles on `input` and `select` from `@apply hover:...` / `@apply focus:...` variants (nested inside `.container`) into explicit `.container input:hover` / `.container select:focus` rules. This prevents the pseudo-class from binding to `.container` (which would cause hovering the `<label>` to trigger the field's hover state) and makes the cascade behavior unambiguous.
- Add an explicit brand-color focus ring so focused inputs no longer fall back to the browser's native blue outline.

## Test plan

- [x] `pnpm build:crx` and reload the unpacked extension
- [x] Open the popup: Name and URL inputs both show a 1px border at rest
- [x] Hover each input/select: brand-primary ring appears only when hovering the field itself, not when hovering the label above it
- [x] Focus each input/select: brand-primary ring (not browser blue) appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)